### PR TITLE
Update the library version to 3.0.0. Add rootDir setting to tsconfig.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfsquad/authentication",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "",
   "scripts": {
     "prepare": "npm run build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
       "target": "es2015",
       "lib": ["es2015", "dom"],
       "declaration": true,
-      "outDir": "./dist"
+      "outDir": "./dist",
+      "rootDir": "./src"
     },
     "include": [
       "src"


### PR DESCRIPTION
This PR updates the version of the library to 3.0.0 from 2.1.0. The reason is that, although the library is backward compatible, the consumers of it should not get updated automatically. Changing the major version forces (most of) the library users to update manually is needed. This prevent potential integration issues.